### PR TITLE
cff: Fix version number

### DIFF
--- a/src/tables/sfnt.mjs
+++ b/src/tables/sfnt.mjs
@@ -337,7 +337,7 @@ function fontToSfntTable(font) {
 
     const postTable = post.make(font);
     const cffTable = cff.make(font.glyphs, {
-        version: font.getEnglishName('version'),
+        version: font.tables.cff && font.tables.cff.topDict || font.getEnglishName('version'),
         fullName: englishFullName,
         familyName: englishFamilyName,
         weightName: englishStyleName,


### PR DESCRIPTION
[why]
The version number written out to a buffer is not the number stored in font.tables.cff.topDict.version. Instead some other human readable string is used even if the cff.topDict.version has been set correctly.

The CFF version number needs to be a string representing a number and nothing else; especially it should not contain 'Version'.

Documentation [1] says this:
    version 0 SID
    This can be derived by copying the OpenType 'head' fsRevision
    field, and formatting it as a Fixed with three decimal places of
    precision.

The documentation is also valid for CFF1 in this regard.

[how]
Use the version string in the CFF table, if there is one. If not fall back to the (imho wrong) previous defaulting behavior.

[1] https://learn.microsoft.com/en-us/typography/opentype/otspec180/cff2#sectionD3

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I did `npm run test` and all tests passed green (including code styling checks).
- [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the **README** accordingly.
- [ ] I have read the **Contribute** README section.
